### PR TITLE
xlsx: Lowercase the sheet names and strip special chars if using -a

### DIFF
--- a/xlsx/xlsx.go
+++ b/xlsx/xlsx.go
@@ -104,7 +104,8 @@ func (f *File) GenerateCSVsFromAllSheets(outFilepath string, csvOpts csvOptSette
 	}
 
 	for i := 0; i < f.SheetCount(); i++ {
-		outFile, err := GetOutFile(keys[i]+".csv", outFilepath)
+		sheetFilename := getSheetFilename(keys[i]+".csv")
+		outFile, err := GetOutFile(sheetFilename, outFilepath)
 		if err != nil {
 			return err
 		}
@@ -135,5 +136,5 @@ func getSheetFilename(sheetName string) string {
 	reg := regexp.MustCompile("[^a-zA-Z0-9_.]+")
 	name = reg.ReplaceAllString(name, "")
 
-	return name + ".csv"
+	return name
 }


### PR DESCRIPTION
Use `getSheetFilename()` to strip special chars when generating CSVs from all sheets in a workboook